### PR TITLE
19-로그인-유지

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script>
-import api from '@/api/modules/accounts'
+import accountsApi from '@/api/modules/accounts'
 import postApi from '@/api/modules/post'
 import AppBar from '@/components/Common/AppBar.vue'
 
@@ -25,7 +25,8 @@ export default {
   components: { AppBar },
 
   async created () {
-    api.getMyDetail()
+    if (localStorage.getItem('refresh_token')) await accountsApi.refreshToken()
+    accountsApi.getMyDetail()
     await postApi.getTopicCategories()
   }
 }

--- a/src/api/modules/accounts.js
+++ b/src/api/modules/accounts.js
@@ -8,16 +8,17 @@ export default {
     myAxios
       .post(Urls.accounts_Register, postData)
       .then(response => {
+        store.commit('userStore/dialogClose', 'register')
         store.commit('userStore/dialogOpen', 'login')
       })
   },
 
-  login (postData) {
+  login (postData, remember) {
     myAxios
       .post(Urls.accounts_Login, postData)
       .then(response => {
         localStorage.setItem('access_token', response.data['access_token'])
-        localStorage.setItem('refresh_token', response.data['refresh_token'])
+        if (remember) localStorage.setItem('refresh_token', response.data['refresh_token'])
         this.getMyDetail()
       })
   },
@@ -27,13 +28,14 @@ export default {
       .post(Urls.accounts_Logout)
       .then(response => {
         localStorage.removeItem('access_token')
+        localStorage.removeItem('refresh_token')
         alert(`${userStore.state.user.username}님이 로그아웃 하셨습니다.`)
         store.commit('userStore/logoutSuccess', response.data)
       })
   },
 
-  refreshToken () {
-    myAxios
+  async refreshToken () {
+    await myAxios
       .post(Urls.accounts_TokenRefresh, {'refresh': localStorage.getItem('refresh_token')})
       .then(response => {
         localStorage.setItem('access_token', response.data['access'])

--- a/src/components/Common/LogIn.vue
+++ b/src/components/Common/LogIn.vue
@@ -23,7 +23,7 @@
           ></v-text-field>
           <v-row align="center" justify="center">
             <v-col>
-              <v-checkbox color="secondary">
+              <v-checkbox color="secondary" v-model="remember">
                 <template v-slot:label>로그인을 유지합니다.</template>
               </v-checkbox>
             </v-col>
@@ -68,14 +68,15 @@ import api from '@/api/modules/accounts'
 export default {
   data: () => ({
     email: '',
-    password: ''
+    password: '',
+    remember: false
   }),
   computed: {
     ...mapState('userStore', ['dialog', 'isLogin', 'user'])
   },
   methods: {
     save () {
-      api.login({ email: this.email, password: this.password })
+      api.login({ email: this.email, password: this.password }, this.remember)
       this.$refs.loginForm.reset()
     }
   }

--- a/src/store/modules/userStore.js
+++ b/src/store/modules/userStore.js
@@ -21,6 +21,13 @@ const userStore = {
         state.dialog.register = true
       }
     },
+    dialogClose (state, kind) {
+      if (kind === 'login') {
+        state.dialog.login = false
+      } else if (kind === 'register') {
+        state.dialog.register = false
+      }
+    },
     loginSuccess (state, userDetail) {
       state.isLogin = true
       state.user = userDetail


### PR DESCRIPTION
로그인을 유지합니다 선택에 따라 토큰 구별하여 처리

- '로그인을 유지합니다'를 선택하지 않으면 : Refresh Token을 저장하지 않음
- '로그인을 유지합니다'를 선택하면 : Refresh Token을 저장, 다음 방문 시 local storage 검사 후 Refresh Token을 이용해 새로 Access Token 발급 받아 로그인 유지